### PR TITLE
Clean up HTML doc and missing license file

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2020 Ben Brewer
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+of the Software, and to permit persons to whom the Software is furnished to do
+so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,8 +1,16 @@
 # XmlJson
 
+[![hex.pm](https://img.shields.io/hexpm/v/xml_json.svg)](https://hex.pm/packages/xml_json)
+[![hex.pm](https://img.shields.io/hexpm/dt/xml_json.svg)](https://hex.pm/packages/xml_json)
+[![hex.pm](https://img.shields.io/hexpm/l/xml_json.svg)](https://hex.pm/packages/xml_json)
+[![github.com](https://img.shields.io/github/last-commit/bennyhat/xml_json.svg)](https://github.com/bennyhat/xml_json)
+
 Should you convert XML to JSON? Probably not.
 
-If you have to though (and have decent control over the providers and consumers of the XML and JSON), then there are some decent conventions out there for lossless and near-lossless conversion, such as:
+If you have to though (and have decent control over the providers and consumers
+of the XML and JSON), then there are some decent conventions out there for
+lossless and near-lossless conversion, such as:
+
 - [`abdera`](http://wiki.open311.org/JSON_and_XML_Conversion/#the-abdera-convention)
 - [`badgerfish`](http://www.sklar.com/badgerfish/)
 - [`cobra`](http://wiki.open311.org/JSON_and_XML_Conversion/#the-cobra-convention)
@@ -10,9 +18,13 @@ If you have to though (and have decent control over the providers and consumers 
 - [`parker`](https://developer.mozilla.org/en-US/docs/Archive/JXON#The_Parker_Convention) (pretty lossy, but my personal favorite)
 - [`yahoo`](https://developer.yahoo.com/yql/guide/response.html#response-xml-to-json) (okay, maybe they're not all great, but they tried)
 
-Presently this only supports Parker and BadgerFish and is largely happy path testing with the examples provided by each convention. That being said, eventually this will come up to a `> 0` major version when that is all worked out.
+Presently this only supports Parker and BadgerFish and is largely happy path
+testing with the examples provided by each convention. That being said,
+eventually this will come up to a `> 0` major version when that is all worked
+out.
 
-Otherwise, this does NOT handle massive XML documents with grace, as it converts to a full JSON/Map object in memory.
+Otherwise, this does NOT handle massive XML documents with grace, as it
+converts to a full JSON/Map object in memory.
 
 A port of the great Python library [`xmljson`](https://pypi.org/project/xmljson/)
 
@@ -38,8 +50,8 @@ iex> XmlJson.BadgerFish.serialize(%{"root" => %{"@attr" => "hello", "dog" => %{"
 
 ## Installation
 
-If [available in Hex](https://hex.pm/docs/publish), the package can be installed
-by adding `xml_json` to your list of dependencies in `mix.exs`:
+The package can be installed by adding `xml_json` to your list of dependencies
+in `mix.exs`:
 
 ```elixir
 def deps do
@@ -49,7 +61,8 @@ def deps do
 end
 ```
 
-Documentation can be generated with [ExDoc](https://github.com/elixir-lang/ex_doc)
-and published on [HexDocs](https://hexdocs.pm). Once published, the docs can
-be found at [https://hexdocs.pm/xml_json](https://hexdocs.pm/xml_json).
+The docs can be found at [https://hexdocs.pm/xml_json](https://hexdocs.pm/xml_json).
 
+## License
+
+[MIT](LICENSE) Copyright (c) 2020 Ben Brewer

--- a/mix.exs
+++ b/mix.exs
@@ -1,6 +1,8 @@
 defmodule XmlJson.MixProject do
   use Mix.Project
 
+  @source_url "https://github.com/bennyhat/xml_json"
+
   def project do
     [
       app: :xml_json,
@@ -12,7 +14,7 @@ defmodule XmlJson.MixProject do
       docs: docs(),
       package: package(),
       name: "XmlJson",
-      source_url: "https://github.com/bennyhat/xml_json"
+      source_url: @source_url
     ]
   end
 
@@ -35,10 +37,11 @@ defmodule XmlJson.MixProject do
 
   defp docs() do
     [
-      source_url: "https://github.com/bennyhat/xml_json",
-      extras: ["README.md"],
       main: "readme",
-      source_url_pattern: "https://github.com/bennyhat/xml_json/blob/master/%{path}#L%{line}"
+      canonical: "http://hexdocs.pm/xml_json",
+      source_url: @source_url,
+      source_url_pattern: "#{@source_url}/xml_json/blob/master/%{path}#L%{line}",
+      extras: ["README.md", "LICENSE"]
     ]
   end
 
@@ -46,7 +49,7 @@ defmodule XmlJson.MixProject do
     [
       maintainers: ["bennyhat"],
       licenses: ["MIT"],
-      links: %{"GitHub" => "https://github.com/bennyhat/xml_json"}
+      links: %{"GitHub" => @source_url}
     ]
   end
 end


### PR DESCRIPTION
This PR refactors the HTML doc generation which includes:

- Use common source URL
- Add link back to Github URL for function header.
- Add missing license file.
- Badges and more badges.