### PR TITLE
fixes issue with single-element xml

### DIFF
--- a/lib/xml_json/parker/deserializer.ex
+++ b/lib/xml_json/parker/deserializer.ex
@@ -49,6 +49,7 @@ defmodule XmlJson.Parker.Deserializer do
   defp maybe_hoist_children(parker) when map_size(parker) == 1 do
     case Map.values(parker) do
       [list] when is_list(list) -> list
+      [map] when is_map(map) -> [map]
       _ -> parker
     end
   end


### PR DESCRIPTION
when deserializing an xml with only one element in a tree, like so: 
```
<s:Envelope xmlns:s=\"http://schemas.xmlsoap.org/soap/envelope/\"> 
    <s:Body>
        <FinancialYearGetListByDepartmentResponse xmlns=\"http://tempuri.org/\"> 
            <FinancialYearGetListByDepartmentResult xmlns:a=\"http://schemas.datacontract.org/xxxxx" xmlns:i=\"http://www.w3.org/2001/XMLSchema-instance\"> 
            <a:FinancialYear>
                <a:Concluded>false</a:Concluded>
                <a:EndDate>2021-07-31T00:00:00</a:EndDate>
                <a:StartDate>2020-08-01T00:00:00</a:StartDate>
            </a:FinancialYear>
            </FinancialYearGetListByDepartmentResult>
        </FinancialYearGetListByDepartmentResponse>
    </s:Body>
</s:Envelope>
```
the original behaviour was to output a map with a nested element like this
```
%{                                                                                                                                                                                                                                              "s:Body" => %{                                                                                                                                                              
    "FinancialYearGetListByDepartmentResponse" => %{
      "FinancialYearGetListByDepartmentResult" => %{
        "a:FinancialYear" => %{
          "a:Concluded" => false,
          "a:EndDate" => "2021-07-31T00:00:00",
          "a:StartDate" => "2020-08-01T00:00:00"
        }
      }
    }
  }
}
``` 

I don't know the details of the Parker standard, but that seems highly unusual, at least it's not really usable since the difference between this and the output of a list of  elements (when the xml contains more than one child) seems unreasonably big. 

So, this fix forms the output of `XmlJson.Parker.deserialize(xml)` when xml is like above, to be a list with one element:
```
[
       %{
             "a:Concluded" => false,
             "a:EndDate" => "2021-07-31T00:00:00",
             "a:StartDate" => "2020-08-01T00:00:00"
        }
]
```

