### PR TITLE
fix for xml doc without child elements

### DIFF
--- a/lib/xml_json/parker/deserializer.ex
+++ b/lib/xml_json/parker/deserializer.ex
@@ -49,10 +49,14 @@ defmodule XmlJson.Parker.Deserializer do
   defp maybe_hoist_children(parker) when map_size(parker) == 1 do
     case Map.values(parker) do
       [list] when is_list(list) -> list
-      [map] when is_map(map) -> [map]
+      [map] when is_map(map) -> 
+        case Map.values(map) do 
+          [nil] -> []
+          _ -> [map]  
+        end
       _ -> parker
     end
-  end
+ end
 
   defp maybe_hoist_children(parker), do: parker
 


### PR DESCRIPTION
This rather ugly code bit fixes an issue my last PR introduced, where (in my use case) a SOAP-response XML with NO child elements at the deepest level would return 
```
[
    %{"SomeKey" => nil}
] 
```

While that is somehow correct technically, receiving an empty list when there are no child elements in the XML seems more logical.