### PR TITLE
Add `try_parse` option for XML deserialization

### DIFF
--- a/lib/xml_json/aws_api.ex
+++ b/lib/xml_json/aws_api.ex
@@ -11,14 +11,17 @@ defmodule XmlJson.AwsApi do
 
   @type aws_api_options ::
           %{
-            list_element_names: list(binary())
+            list_element_names: list(binary()),
+            try_parse: boolean()
           }
           | [
-              list_element_names: list(binary())
+              list_element_names: list(binary()),
+              try_parse: boolean()
             ]
 
   @default_opts %{
-    list_element_names: ["member"]
+    list_element_names: ["member"],
+    try_parse: true
   }
 
   @doc """

--- a/lib/xml_json/aws_api/deserializer.ex
+++ b/lib/xml_json/aws_api/deserializer.ex
@@ -7,7 +7,7 @@ defmodule XmlJson.AwsApi.Deserializer do
 
   @spec deserialize(binary(), map()) :: {:ok, map()} | {:error, Saxy.ParseError.t()}
   def deserialize(xml, opts) do
-    case SaxHandler.parse_string(xml) do
+    case SaxHandler.parse_string(xml, opts) do
       {:ok, element} ->
         {:ok, %{element.name => walk_element(element, opts)}}
 

--- a/lib/xml_json/badgerfish.ex
+++ b/lib/xml_json/badgerfish.ex
@@ -10,15 +10,18 @@ defmodule XmlJson.BadgerFish do
 
   @type badgerfish_options ::
           %{
-            exclude_namespaces: boolean()
+            exclude_namespaces: boolean(),
+            try_parse: boolean()
           }
           | [
-              exclude_namespaces: boolean()
+              exclude_namespaces: boolean(),
+              try_parse: boolean()
             ]
 
   @default_opts %{
     exclude_namespaces: false,
-    ns_keys: []
+    ns_keys: [],
+    try_parse: true
   }
 
   @doc """

--- a/lib/xml_json/badgerfish/deserializer.ex
+++ b/lib/xml_json/badgerfish/deserializer.ex
@@ -7,7 +7,7 @@ defmodule XmlJson.BadgerFish.Deserializer do
 
   @spec deserialize(binary(), map()) :: {:ok, map()} | {:error, Saxy.ParseError.t()}
   def deserialize(xml, opts) do
-    case SaxHandler.parse_string(xml) do
+    case SaxHandler.parse_string(xml, opts) do
       {:ok, element} ->
         {:ok, %{element.name => walk_element(element, opts)}}
 

--- a/lib/xml_json/parker.ex
+++ b/lib/xml_json/parker.ex
@@ -10,14 +10,17 @@ defmodule XmlJson.Parker do
 
   @type parker_options ::
           %{
-            preserve_root: boolean() | binary()
+            preserve_root: boolean() | binary(),
+            try_parse: boolean()
           }
           | [
-              preserve_root: boolean() | binary()
+              preserve_root: boolean() | binary(),
+              try_parse: boolean()
             ]
 
   @default_opts %{
-    preserve_root: false
+    preserve_root: false,
+    try_parse: true
   }
 
   @doc """

--- a/lib/xml_json/parker/deserializer.ex
+++ b/lib/xml_json/parker/deserializer.ex
@@ -7,7 +7,7 @@ defmodule XmlJson.Parker.Deserializer do
 
   @spec deserialize(binary(), map()) :: {:ok, map()} | {:error, Saxy.ParseError.t()}
   def deserialize(xml, opts) do
-    case SaxHandler.parse_string(xml) do
+    case SaxHandler.parse_string(xml, opts) do
       {:ok, element} ->
         walk_element(element)
         |> maybe_preserve_root(element, opts)
@@ -48,15 +48,19 @@ defmodule XmlJson.Parker.Deserializer do
 
   defp maybe_hoist_children(parker) when map_size(parker) == 1 do
     case Map.values(parker) do
-      [list] when is_list(list) -> list
-      [map] when is_map(map) -> 
-        case Map.values(map) do 
+      [list] when is_list(list) ->
+        list
+
+      [map] when is_map(map) ->
+        case Map.values(map) do
           [nil] -> []
-          _ -> [map]  
+          _ -> [map]
         end
-      _ -> parker
+
+      _ ->
+        parker
     end
- end
+  end
 
   defp maybe_hoist_children(parker), do: parker
 

--- a/test/xml_json/parker_test.exs
+++ b/test/xml_json/parker_test.exs
@@ -99,6 +99,21 @@ defmodule XmlJson.ParkerTest do
 
       assert {:ok, %{"ding:dong" => "binnen"}} == XmlJson.Parker.deserialize(xml)
     end
+
+    test "do not parse values as numbers or booleans if requested" do
+      xml = """
+      <root>123</root>
+      """
+
+      assert {:ok, %{"root" => "123"}} ==
+               XmlJson.Parker.deserialize(xml, try_parse: false, preserve_root: true)
+
+      assert {:ok, "123"} ==
+               XmlJson.Parker.deserialize(xml, try_parse: false)
+
+      assert {:ok, 123} ==
+               XmlJson.Parker.deserialize(xml, try_parse: true)
+    end
   end
 
   describe "deserialize!/2" do


### PR DESCRIPTION
- Introduced a `try_parse` boolean option to control parsing behavior in `aws_api`, `badgerfish`, and `parker` modules.
- Updated the `SaxHandler` to accept the `try_parse` option and adjust parsing logic accordingly.
- Modified deserializers to pass options to `SaxHandler`.
- Added test cases in `parker_test.exs` to verify the new `try_parse` functionality.

## Discussion

I was using this to parse parameters for an XML API that we are serving with Elixir.
I stumbled upon the issue, that params are (unnecessarily) parsed and casted to numbers and booleans.
While is this helpful for JSON compatibility, I found it unhelpful, also because Ecto `:string` types do not cast from a number to a string.
So having a field that is supposed to be a string, I would have to maintain my own `Ecto.Type` just to parse those numbers back into strings.

So I guess for using this as an API, it might make more sense to leave values as strings.

Therefore I added the `:try_parse` option which allows turning off the parsing behavior.